### PR TITLE
CRTK interface update

### DIFF
--- a/scripts/surgical_robotics_challenge/examples/crtk_ros_based_control.py
+++ b/scripts/surgical_robotics_challenge/examples/crtk_ros_based_control.py
@@ -43,7 +43,7 @@
 # */
 # //==============================================================================
 
-from geometry_msgs.msg import TransformStamped
+from geometry_msgs.msg import PoseStamped
 from sensor_msgs.msg import JointState
 from geometry_msgs.msg import TwistStamped
 import rospy
@@ -54,7 +54,7 @@ from PyKDL import Rotation
 class RobotData:
     def __init__(self):
         self.measured_js = JointState()
-        self.measured_cp = TransformStamped()
+        self.measured_cp = PoseStamped()
 
 
 robData = RobotData()
@@ -77,27 +77,25 @@ measured_cp_name = namespace + arm_name + "/measured_cp"
 servo_jp_name = namespace + arm_name + "/servo_jp"
 servo_cp_name = namespace + arm_name + "/servo_cp"
 
-measured_js_sub = rospy.Subscriber(
-    measured_js_name, JointState, measured_js_cb, queue_size=1)
-measured_cp_sub = rospy.Subscriber(
-    measured_cp_name, TransformStamped, measured_cp_cb, queue_size=1)
+measured_js_sub = rospy.Subscriber(measured_js_name, JointState, measured_js_cb, queue_size=1)
+measured_cp_sub = rospy.Subscriber(measured_cp_name, PoseStamped, measured_cp_cb, queue_size=1)
 
 servo_jp_pub = rospy.Publisher(servo_jp_name, JointState, queue_size=1)
-servo_cp_pub = rospy.Publisher(servo_cp_name, TransformStamped, queue_size=1)
+servo_cp_pub = rospy.Publisher(servo_cp_name, PoseStamped, queue_size=1)
 
 rate = rospy.Rate(50)
 
 servo_jp_msg = JointState()
 servo_jp_msg.position = [0., 0., 1.0, 0., 0., 0.]
 
-servo_cp_msg = TransformStamped()
-servo_cp_msg.transform.translation.z = -1.0
+servo_cp_msg = PoseStamped()
+servo_cp_msg.pose.position.z = -1.0
 R_7_0 = Rotation.RPY(3.14, 0.0, 1.57079)
 
-servo_cp_msg.transform.rotation.x = R_7_0.GetQuaternion()[0]
-servo_cp_msg.transform.rotation.y = R_7_0.GetQuaternion()[1]
-servo_cp_msg.transform.rotation.z = R_7_0.GetQuaternion()[2]
-servo_cp_msg.transform.rotation.w = R_7_0.GetQuaternion()[3]
+servo_cp_msg.pose.orientation.x = R_7_0.GetQuaternion()[0]
+servo_cp_msg.pose.orientation.y = R_7_0.GetQuaternion()[1]
+servo_cp_msg.pose.orientation.z = R_7_0.GetQuaternion()[2]
+servo_cp_msg.pose.orientation.w = R_7_0.GetQuaternion()[3]
 
 valid_key = False
 key = None
@@ -124,7 +122,7 @@ while not rospy.is_shutdown():
     if key == 1:
         print("measured_js: ", robData.measured_js)
         print("------------------------------------")
-        print("measured_cp: ", robData.measured_cp.transform)
+        print("measured_cp: ", robData.measured_cp.pose)
 
     # ######
     # The following 3 lines move the first two joints in a sinusoidal pattern
@@ -136,10 +134,8 @@ while not rospy.is_shutdown():
     # ######
     # The following 3 lines move the robot in cartesian space in sinusoidal fashion
     elif key == 3:
-        servo_cp_msg.transform.translation.x = 0.2 * \
-            math.sin(rospy.Time.now().to_sec())
-        servo_cp_msg.transform.translation.y = 0.2 * \
-            math.cos(rospy.Time.now().to_sec())
+        servo_cp_msg.pose.position.x = 0.2 * math.sin(rospy.Time.now().to_sec())
+        servo_cp_msg.pose.position.y = 0.2 * math.cos(rospy.Time.now().to_sec())
         servo_cp_pub.publish(servo_cp_msg)
 
     rate.sleep()

--- a/scripts/surgical_robotics_challenge/examples/interface_via_crtk_ros_api.py
+++ b/scripts/surgical_robotics_challenge/examples/interface_via_crtk_ros_api.py
@@ -1,6 +1,6 @@
 # Import the relevant classes
 import rospy
-from geometry_msgs.msg import TransformStamped, PoseStamped
+from geometry_msgs.msg import PoseStamped
 from sensor_msgs.msg import JointState
 from PyKDL import Frame, Rotation, Vector
 import time
@@ -30,17 +30,17 @@ class ArmType(Enum):
     ECM=3
 
 
-def frame_to_transform_stamped_msg(frame):
-    msg = TransformStamped()
+def frame_to_pose_stamped_msg(frame):
+    msg = PoseStamped()
     msg.header.stamp = rospy.Time.now()
-    msg.transform.translation.x = frame.p[0]
-    msg.transform.translation.y = frame.p[1]
-    msg.transform.translation.z = frame.p[2]
+    msg.pose.position.x = frame.p[0]
+    msg.pose.position.y = frame.p[1]
+    msg.pose.position.z = frame.p[2]
 
-    msg.transform.rotation.x = frame.M.GetQuaternion()[0]
-    msg.transform.rotation.y = frame.M.GetQuaternion()[1]
-    msg.transform.rotation.z = frame.M.GetQuaternion()[2]
-    msg.transform.rotation.w = frame.M.GetQuaternion()[3]
+    msg.pose.orientation.x = frame.M.GetQuaternion()[0]
+    msg.pose.orientation.y = frame.M.GetQuaternion()[1]
+    msg.pose.orientation.z = frame.M.GetQuaternion()[2]
+    msg.pose.orientation.w = frame.M.GetQuaternion()[3]
 
     return msg
 
@@ -62,10 +62,10 @@ class ARMInterface:
         else:
             raise ("Error! Invalid Arm Type")
 
-        self._cp_sub = rospy.Subscriber(arm_name + "/measured_cp", TransformStamped, self.cp_cb, queue_size=1)
-        self._T_b_w_sub = rospy.Subscriber(arm_name + "/T_b_w", TransformStamped, self.T_b_w_cb, queue_size=1)
+        self._cp_sub = rospy.Subscriber(arm_name + "/measured_cp", PoseStamped, self.cp_cb, queue_size=1)
+        self._T_b_w_sub = rospy.Subscriber(arm_name + "/T_b_w", PoseStamped, self.T_b_w_cb, queue_size=1)
         self._jp_sub = rospy.Subscriber(arm_name + "/measured_cp", JointState, self.jp_cb, queue_size=1)
-        self.cp_pub = rospy.Publisher(arm_name + "/servo_cp", TransformStamped, queue_size=1)
+        self.cp_pub = rospy.Publisher(arm_name + "/servo_cp", PoseStamped, queue_size=1)
         self.jp_pub = rospy.Publisher(arm_name + "/servo_jp", JointState, queue_size=1)
         self.jaw_jp_pub = rospy.Publisher(arm_name + '/jaw/' + 'servo_jp', JointState, queue_size=1)
 
@@ -93,7 +93,7 @@ class ARMInterface:
 
     def servo_cp(self, pose):
         if type(pose) == Frame:
-            msg = frame_to_transform_stamped_msg(pose)
+            msg = frame_to_pose_stamped_msg(pose)
         else:
             msg = pose
         self.cp_pub.publish(msg)
@@ -139,7 +139,7 @@ class SceneInterface:
         namespace = '/CRTK/'
         suffix = '/measured_cp'
         for k, i in self._scene_object_poses.items():
-            self._subs.append(rospy.Subscriber(namespace + k.name + suffix, TransformStamped,
+            self._subs.append(rospy.Subscriber(namespace + k.name + suffix, PoseStamped,
                                                self.state_cb, callback_args=k, queue_size=1))
 
     def state_cb(self, msg, key):

--- a/scripts/surgical_robotics_challenge/launch_crtk_interface.py
+++ b/scripts/surgical_robotics_challenge/launch_crtk_interface.py
@@ -154,6 +154,7 @@ class PSMCRTKWrapper:
         self._jaw_angle = jp.position[0]
 
     def publish_js(self):
+        self._measured_js_msg.header.stamp = rospy.Time.now()
         self._measured_js_msg.position = self.arm.measured_jp()
         self._measured_js_msg.velocity = self.arm.measured_jv()
         self.measured_js_pub.publish(self._measured_js_msg)
@@ -163,10 +164,12 @@ class PSMCRTKWrapper:
         self.arm.run_grasp_logic(self._jaw_angle)
 
     def publish_cs(self):
+        self._measured_cp_msg.header.stamp = rospy.Time.now()
         self._measured_cp_msg.pose = np_mat_to_pose(self.arm.measured_cp())
         self.measured_cp_pub.publish(self._measured_cp_msg)
 
     def publish_T_b_w(self):
+        self._T_b_w_msg.header.stamp = rospy.Time.now()
         self._T_b_w_msg.pose = np_mat_to_pose(self.arm.get_T_b_w())
         self.T_b_w_pub.publish(self._T_b_w_msg)
 
@@ -220,10 +223,12 @@ class ECMCRTKWrapper:
     #     self.arm.servo_jv(js.velocity)
 
     def publish_js(self):
+        self._measured_js_msg.header.stamp = rospy.Time.now()
         self._measured_js_msg.position = self.arm.measured_jp()
         self.measured_js_pub.publish(self._measured_js_msg)
 
     def publish_cs(self):
+        self._measured_cp_msg.header.stamp = rospy.Time.now()
         self._measured_cp_msg.pose = np_mat_to_pose(self.arm.measured_cp())
         self.measured_cp_pub.publish(self._measured_cp_msg)
 
@@ -266,6 +271,7 @@ class SceneCRTKWrapper:
 
     def publish_cs(self):
         for k, i in self._scene_object_pubs.items():
+            i[2].header.stamp = rospy.Time.now()
             i[2].pose = np_mat_to_pose(i[1]())
             i[0].publish(i[2])
 

--- a/scripts/surgical_robotics_challenge/launch_crtk_interface.py
+++ b/scripts/surgical_robotics_challenge/launch_crtk_interface.py
@@ -135,7 +135,7 @@ class PSMCRTKWrapper:
         self._measured_js_msg.name = self.arm.get_joint_names()
 
         self._measured_cp_msg = PoseStamped()
-        self._measured_cp_msg.header.frame_id = 'baselink'
+        self._measured_cp_msg.header.frame_id = name + '/baselink'
         self._T_b_w_msg = PoseStamped()
         self._T_b_w_msg.header.frame_id = 'world'
         self._jaw_angle = 0.5
@@ -203,7 +203,7 @@ class ECMCRTKWrapper:
         self._measured_js_msg.name = ["j0", "j1", "j2", "j3"]
 
         self._measured_cp_msg = PoseStamped()
-        self._measured_cp_msg.header.frame_id = 'baselink'
+        self._measured_cp_msg.header.frame_id = name + '/baselink'
 
         self._measured_cv_msg = TwistStamped()
         self._measured_cv_msg.header.frame_id = 'world'

--- a/scripts/surgical_robotics_challenge/launch_crtk_interface.py
+++ b/scripts/surgical_robotics_challenge/launch_crtk_interface.py
@@ -40,6 +40,7 @@
 #     \version   1.0
 # */
 # //==============================================================================
+
 import rospy
 from ambf_client import Client
 import psm_arm
@@ -47,7 +48,7 @@ import ecm_arm
 import scene
 import time
 from sensor_msgs.msg import JointState
-from geometry_msgs.msg import TransformStamped, Transform, TwistStamped
+from geometry_msgs.msg import PoseStamped, Pose, TwistStamped
 from PyKDL import Rotation, Vector, Frame
 from argparse import ArgumentParser
 from surgical_robotics_challenge.utils.utilities import get_boolean_from_opt
@@ -62,30 +63,30 @@ def rot_mat_to_quat(cp):
     return R.GetQuaternion()
 
 
-def np_mat_to_transform(cp):
-    trans = Transform()
-    trans.translation.x = cp[0, 3]
-    trans.translation.y = cp[1, 3]
-    trans.translation.z = cp[2, 3]
+def np_mat_to_pose(cp):
+    pose = Pose()
+    pose.position.x = cp[0, 3]
+    pose.position.y = cp[1, 3]
+    pose.position.z = cp[2, 3]
 
     Quat = rot_mat_to_quat(cp)
 
-    trans.rotation.x = Quat[0]
-    trans.rotation.y = Quat[1]
-    trans.rotation.z = Quat[2]
-    trans.rotation.w = Quat[3]
-    return trans
+    pose.orientation.x = Quat[0]
+    pose.orientation.y = Quat[1]
+    pose.orientation.z = Quat[2]
+    pose.orientation.w = Quat[3]
+    return pose
 
 
-def transform_to_frame(cp):
+def pose_to_frame(cp):
     frame = Frame()
-    frame.p = Vector(cp.translation.x,
-                     cp.translation.y,
-                     cp.translation.z)
-    frame.M = Rotation.Quaternion(cp.rotation.x,
-                                  cp.rotation.y,
-                                  cp.rotation.z,
-                                  cp.rotation.w)
+    frame.p = Vector(cp.position.x,
+                     cp.position.y,
+                     cp.position.z)
+    frame.M = Rotation.Quaternion(cp.orientation.x,
+                                  cp.orientation.y,
+                                  cp.orientation.z,
+                                  cp.orientation.w)
     return frame
 
 
@@ -109,11 +110,11 @@ class PSMCRTKWrapper:
         self.measured_js_pub = rospy.Publisher(namespace + '/' + name + '/' + 'measured_js', JointState,
                                                queue_size=1)
 
-        self.measured_cp_pub = rospy.Publisher(namespace + '/' + name + '/' + 'measured_cp', TransformStamped,
+        self.measured_cp_pub = rospy.Publisher(namespace + '/' + name + '/' + 'measured_cp', PoseStamped,
                                                queue_size=1)
 
-        self.T_b_w_pub = rospy.Publisher(namespace + '/' + name + '/' + 'T_b_w', TransformStamped,
-                                               queue_size=1)
+        self.T_b_w_pub = rospy.Publisher(namespace + '/' + name + '/' + 'T_b_w', PoseStamped,
+                                         queue_size=1)
 
         self.measured_cv_pub = rospy.Publisher(namespace + '/' + name + '/' + 'measured_cv', TwistStamped,
                                                queue_size=1)
@@ -124,7 +125,7 @@ class PSMCRTKWrapper:
         self.servo_jv_sub = rospy.Subscriber(namespace + '/' + name + '/' + 'servo_jv', JointState,
                                              self.servo_jv_cb, queue_size=1)
 
-        self.servo_cp_sub = rospy.Subscriber(namespace + '/' + name + '/' + 'servo_cp', TransformStamped,
+        self.servo_cp_sub = rospy.Subscriber(namespace + '/' + name + '/' + 'servo_cp', PoseStamped,
                                              self.servo_cp_cb, queue_size=1)
 
         self.servo_jaw_jp_sub = rospy.Subscriber(namespace + '/' + name + '/jaw/' + 'servo_jp', JointState,
@@ -133,14 +134,14 @@ class PSMCRTKWrapper:
         self._measured_js_msg = JointState()
         self._measured_js_msg.name = self.arm.get_joint_names()
 
-        self._measured_cp_msg = TransformStamped()
+        self._measured_cp_msg = PoseStamped()
         self._measured_cp_msg.header.frame_id = 'baselink'
-        self._T_b_w_msg = TransformStamped()
+        self._T_b_w_msg = PoseStamped()
         self._T_b_w_msg.header.frame_id = 'world'
         self._jaw_angle = 0.5
 
     def servo_cp_cb(self, cp):
-        frame = transform_to_frame(cp.transform)
+        frame = pose_to_frame(cp.pose)
         self.arm.servo_cp(frame)
 
     def servo_jp_cb(self, js):
@@ -162,11 +163,11 @@ class PSMCRTKWrapper:
         self.arm.run_grasp_logic(self._jaw_angle)
 
     def publish_cs(self):
-        self._measured_cp_msg.transform = np_mat_to_transform(self.arm.measured_cp())
+        self._measured_cp_msg.pose = np_mat_to_pose(self.arm.measured_cp())
         self.measured_cp_pub.publish(self._measured_cp_msg)
 
     def publish_T_b_w(self):
-        self._T_b_w_msg.transform = np_mat_to_transform(self.arm.get_T_b_w())
+        self._T_b_w_msg.pose = np_mat_to_pose(self.arm.get_T_b_w())
         self.T_b_w_pub.publish(self._T_b_w_msg)
 
     def run(self):
@@ -186,7 +187,7 @@ class ECMCRTKWrapper:
         self.measured_js_pub = rospy.Publisher(namespace + '/' + name + '/' + 'measured_js', JointState,
                                                queue_size=1)
 
-        self.measured_cp_pub = rospy.Publisher(namespace + '/' + name + '/' + 'measured_cp', TransformStamped,
+        self.measured_cp_pub = rospy.Publisher(namespace + '/' + name + '/' + 'measured_cp', PoseStamped,
                                                queue_size=1)
 
         self.servo_jp_sub = rospy.Subscriber(namespace + '/' + name + '/' + 'servo_jp', JointState,
@@ -195,20 +196,20 @@ class ECMCRTKWrapper:
         # self.servo_jv_sub = rospy.Subscriber(namespace + '/' + name + '/' + 'servo_jv', JointState,
         #                                      self.servo_jv_cb, queue_size=1)
 
-        # self.servo_cp_sub = rospy.Subscriber(namespace + '/' + name + '/' + 'servo_cp', TransformStamped,
+        # self.servo_cp_sub = rospy.Subscriber(namespace + '/' + name + '/' + 'servo_cp', PoseStamped,
         #                                      self.servo_cp_cb, queue_size=1)
 
         self._measured_js_msg = JointState()
         self._measured_js_msg.name = ["j0", "j1", "j2", "j3"]
 
-        self._measured_cp_msg = TransformStamped()
+        self._measured_cp_msg = PoseStamped()
         self._measured_cp_msg.header.frame_id = 'baselink'
 
         self._measured_cv_msg = TwistStamped()
         self._measured_cv_msg.header.frame_id = 'world'
 
     # def servo_cp_cb(self, cp):
-    #     frame = transform_to_frame(cp.transform)
+    #     frame = pose_to_frame(cp.pose)
     #     self.arm.servo_cp(frame)
 
     def servo_jp_cb(self, js):
@@ -223,7 +224,7 @@ class ECMCRTKWrapper:
         self.measured_js_pub.publish(self._measured_js_msg)
 
     def publish_cs(self):
-        self._measured_cp_msg.transform = np_mat_to_transform(self.arm.measured_cp())
+        self._measured_cp_msg.pose = np_mat_to_pose(self.arm.measured_cp())
         self.measured_cp_pub.publish(self._measured_cp_msg)
 
     def run(self):
@@ -248,25 +249,24 @@ class SceneCRTKWrapper:
         self.namespace = namespace
         self.scene = scene.Scene(client)
         self._scene_object_pubs = dict()
-        self._scene_object_pubs[SceneObjectType.Needle] = [None, self.scene.needle_measured_cp, TransformStamped()]
-        self._scene_object_pubs[SceneObjectType.Entry1] = [None, self.scene.entry1_measured_cp, TransformStamped()]
-        self._scene_object_pubs[SceneObjectType.Entry2] = [None, self.scene.entry2_measured_cp, TransformStamped()]
-        self._scene_object_pubs[SceneObjectType.Entry3] = [None, self.scene.entry3_measured_cp, TransformStamped()]
-        self._scene_object_pubs[SceneObjectType.Entry4] = [None, self.scene.entry4_measured_cp, TransformStamped()]
-        self._scene_object_pubs[SceneObjectType.Exit1] = [None, self.scene.exit1_measured_cp, TransformStamped()]
-        self._scene_object_pubs[SceneObjectType.Exit2] = [None, self.scene.exit2_measured_cp, TransformStamped()]
-        self._scene_object_pubs[SceneObjectType.Exit3] = [None, self.scene.exit3_measured_cp, TransformStamped()]
-        self._scene_object_pubs[SceneObjectType.Exit4] = [None, self.scene.exit4_measured_cp, TransformStamped()]
+        self._scene_object_pubs[SceneObjectType.Needle] = [None, self.scene.needle_measured_cp, PoseStamped()]
+        self._scene_object_pubs[SceneObjectType.Entry1] = [None, self.scene.entry1_measured_cp, PoseStamped()]
+        self._scene_object_pubs[SceneObjectType.Entry2] = [None, self.scene.entry2_measured_cp, PoseStamped()]
+        self._scene_object_pubs[SceneObjectType.Entry3] = [None, self.scene.entry3_measured_cp, PoseStamped()]
+        self._scene_object_pubs[SceneObjectType.Entry4] = [None, self.scene.entry4_measured_cp, PoseStamped()]
+        self._scene_object_pubs[SceneObjectType.Exit1] = [None, self.scene.exit1_measured_cp, PoseStamped()]
+        self._scene_object_pubs[SceneObjectType.Exit2] = [None, self.scene.exit2_measured_cp, PoseStamped()]
+        self._scene_object_pubs[SceneObjectType.Exit3] = [None, self.scene.exit3_measured_cp, PoseStamped()]
+        self._scene_object_pubs[SceneObjectType.Exit4] = [None, self.scene.exit4_measured_cp, PoseStamped()]
 
         suffix = '/measured_cp'
         for k, i in self._scene_object_pubs.items():
-            i[0] = rospy.Publisher(namespace + '/' + k.name + suffix,
-                                                            TransformStamped, queue_size=1)
+            i[0] = rospy.Publisher(namespace + '/' + k.name + suffix, PoseStamped, queue_size=1)
             i[2].header.frame_id = 'world'
 
     def publish_cs(self):
         for k, i in self._scene_object_pubs.items():
-            i[2].transform = np_mat_to_transform(i[1]())
+            i[2].pose = np_mat_to_pose(i[1]())
             i[0].publish(i[2])
 
     def run(self):
@@ -335,7 +335,3 @@ if __name__ == "__main__":
 
     sceneManager = SceneManager(options)
     sceneManager.run()
-
-
-
-


### PR DESCRIPTION
Hi,

This PR changes the challenge CRTK interface TransformStamped type to `PoseStamped` according to collaborative-robotics/documentation#1 (discussed in #35).

It also makes two smaller changes:
- prefix different "baselink" frames; and 
- timestamp outgoing messages.